### PR TITLE
Fix item/location count mismatch when ascension_down > 0 with ascension >= 20

### DIFF
--- a/worlds/spire/__init__.py
+++ b/worlds/spire/__init__.py
@@ -276,7 +276,7 @@ class SpireWorld(World):
 
                 if config.final_act:
                     remaining_checks += 4
-                if config.ascension >= 20:
+                if config.ascension >= 20 and config.ascension_down == 0:
                     remaining_checks += 1
 
                 traps: list[bool] = [self.random.randint(0, 100) < self.options.trap_chance for _ in range(remaining_checks)]


### PR DESCRIPTION
The item creation code unconditionally added an extra filler item for ascension >= 20, but the corresponding floor location was only created when ascension_down == 0, causing +1 item surplus per affected character.

4a8a1cef4dba39ece7bb1b9492c0b74878283063 changed the logic for the location creation but didn't update the condition for the item count.
